### PR TITLE
Googleauth

### DIFF
--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/TotpProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/TotpProvider.scala
@@ -26,18 +26,22 @@ import com.mohiva.play.silhouette.impl.providers.TotpProvider._
 import scala.concurrent.Future
 
 /**
- * TOTP authentication information.
+ * TOTP authentication information that should be stored in an authentication repository.
  *
- * @param sharedKey The shared key which is used together with verification code in TOTP-authentication
- * @param scratchCodes The list of scratch codes, which can be used instead of verification codes
+ * @param sharedKey The key associated to an user that together with a verification
+ *                  code enables authentication
+ * @param scratchCodes A sequence of scratch or recovery codes, which can be used as
+ *                     alternative to verification codes
  */
 case class TotpInfo(sharedKey: String, scratchCodes: Seq[String]) extends AuthInfo
 
 /**
- * TOTP authentication credentials data.
+ * TOTP authentication credentials data including an URL to the QR-code for first-time
+ * activation of the TOTP.
  *
- * @param totpInfo The TOTP authentication info
- * @param qrUrl The QR-code that matches this shared key
+ * @param totpInfo The TOTP authentication info that will be persisted in an
+ *                 authentication repository.
+ * @param qrUrl The QR-code that matches this shared key for first time activation
  */
 case class TotpCredentials(totpInfo: TotpInfo, qrUrl: String)
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/TotpProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/TotpProvider.scala
@@ -30,10 +30,10 @@ import scala.concurrent.Future
  *
  * @param sharedKey The key associated to an user that together with a verification
  *                  code enables authentication
- * @param scratchCodes A sequence of scratch or recovery codes, which can be used as
- *                     alternative to verification codes
+ * @param scratchCodes A set of scratch or recovery codes, which can be used each once and
+ *                     as alternative to verification codes
  */
-case class TotpInfo(sharedKey: String, scratchCodes: Seq[String]) extends AuthInfo
+case class TotpInfo(sharedKey: String, scratchCodes: Set[String]) extends AuthInfo
 
 /**
  * TOTP authentication credentials data including an URL to the QR-code for first-time

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/TotpProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/TotpProvider.scala
@@ -19,20 +19,27 @@
  */
 package com.mohiva.play.silhouette.impl.providers
 
+import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.util.ExecutionContextProvider
-import com.mohiva.play.silhouette.api.{ Logger, LoginInfo, Provider }
 import com.mohiva.play.silhouette.impl.providers.TotpProvider._
 
 import scala.concurrent.Future
 
 /**
- * TOTP credentials data.
+ * TOTP authentication information.
  *
- * @param sharedKey The shared key which used together with verification code in TOTP-authentication
+ * @param sharedKey The shared key which is used together with verification code in TOTP-authentication
  * @param scratchCodes The list of scratch codes, which can be used instead of verification codes
- * @param qrUrl The QR-code which contains shared key
  */
-case class TotpCredentials(sharedKey: String, scratchCodes: List[String], qrUrl: String)
+case class TotpInfo(sharedKey: String, scratchCodes: Seq[String]) extends AuthInfo
+
+/**
+ * TOTP authentication credentials data.
+ *
+ * @param totpInfo The TOTP authentication info
+ * @param qrUrl The QR-code that matches this shared key
+ */
+case class TotpCredentials(totpInfo: TotpInfo, qrUrl: String)
 
 /**
  * The base interface for all TOTP (Time-based One-time Password) providers.
@@ -43,7 +50,7 @@ trait TotpProvider extends Provider with ExecutionContextProvider with Logger {
    *
    * @param providerKey A unique key which identifies a user on this provider (userID, email, ...).
    * @param issuer The issuer name. This parameter cannot contain the colon character.
-   * @return The unique shared key.
+   * @return TotpInfo contaning the credentials data including sharedKey and scratch codes.
    */
   def createCredentials(providerKey: String, issuer: Option[String] = None): TotpCredentials
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
@@ -76,7 +76,7 @@ class GoogleTotpProvider @Inject() (implicit val executionContext: ExecutionCont
     val credentials = googleAuthenticator.createCredentials()
     val qrUrl = GoogleAuthenticatorQRGenerator.getOtpAuthURL(issuer.orNull, accountName, credentials)
     val scratchCodes = credentials.getScratchCodes.asScala.map(_.toString).toList
-    TotpCredentials(credentials.getKey, scratchCodes, qrUrl)
+    TotpCredentials(TotpInfo(credentials.getKey, scratchCodes), qrUrl)
   }
 }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
@@ -75,7 +75,7 @@ class GoogleTotpProvider @Inject() (implicit val executionContext: ExecutionCont
   override def createCredentials(accountName: String, issuer: Option[String]): TotpCredentials = {
     val credentials = googleAuthenticator.createCredentials()
     val qrUrl = GoogleAuthenticatorQRGenerator.getOtpAuthURL(issuer.orNull, accountName, credentials)
-    val scratchCodes = credentials.getScratchCodes.asScala.map(_.toString)
+    val scratchCodes = credentials.getScratchCodes.asScala.map(_.toString).toSet
     TotpCredentials(TotpInfo(credentials.getKey, scratchCodes), qrUrl)
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
@@ -95,10 +95,11 @@ class GoogleTotpProvider @Inject() (injectedPasswordHasherRegistry: PasswordHash
     val credentials = googleAuthenticator.createCredentials()
     val qrUrl = GoogleAuthenticatorQRGenerator.getOtpAuthURL(issuer.orNull, accountName, credentials)
     val currentHasher = passwordHasherRegistry.current
-    val hashedScratchCodes = credentials.getScratchCodes.asScala.map { scratchCode =>
-      currentHasher.hash(scratchCode.toString)
+    val scratchCodesPlain = credentials.getScratchCodes.asScala.map(_.toString)
+    val hashedScratchCodes = scratchCodesPlain.map { scratchCode =>
+      currentHasher.hash(scratchCode)
     }
-    TotpCredentials(TotpInfo(credentials.getKey, hashedScratchCodes), qrUrl)
+    TotpCredentials(TotpInfo(credentials.getKey, hashedScratchCodes, Some(scratchCodesPlain)), qrUrl)
   }
 }
 

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext
 import scala.collection.JavaConverters._
 
 /**
- * Google's TOTP authentication provider concrete implementation.
+ * Google's TOTP authentication concrete provider implementation.
  */
 class GoogleTotpProvider @Inject() (implicit val executionContext: ExecutionContext) extends TotpProvider {
   /**
@@ -75,7 +75,7 @@ class GoogleTotpProvider @Inject() (implicit val executionContext: ExecutionCont
   override def createCredentials(accountName: String, issuer: Option[String]): TotpCredentials = {
     val credentials = googleAuthenticator.createCredentials()
     val qrUrl = GoogleAuthenticatorQRGenerator.getOtpAuthURL(issuer.orNull, accountName, credentials)
-    val scratchCodes = credentials.getScratchCodes.asScala.map(_.toString).toList
+    val scratchCodes = credentials.getScratchCodes.asScala.map(_.toString)
     TotpCredentials(TotpInfo(credentials.getKey, scratchCodes), qrUrl)
   }
 }

--- a/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
+++ b/silhouette/app/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProvider.scala
@@ -99,7 +99,7 @@ class GoogleTotpProvider @Inject() (injectedPasswordHasherRegistry: PasswordHash
     val hashedScratchCodes = scratchCodesPlain.map { scratchCode =>
       currentHasher.hash(scratchCode)
     }
-    TotpCredentials(TotpInfo(credentials.getKey, hashedScratchCodes, Some(scratchCodesPlain)), qrUrl)
+    TotpCredentials(TotpInfo(credentials.getKey, hashedScratchCodes), scratchCodesPlain, qrUrl)
   }
 }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/TotpProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/TotpProviderSpec.scala
@@ -16,15 +16,13 @@
 package com.mohiva.play.silhouette.impl.providers
 
 import org.specs2.mock.Mockito
-import org.specs2.specification.Scope
-import play.api.test.PlaySpecification
 
 /**
  * Abstract test case for the [[com.mohiva.play.silhouette.impl.providers.TotpProvider]] based class.
  */
-trait TotpProviderSpec extends PlaySpecification with Mockito {
+trait TotpProviderSpec extends PasswordProviderSpec with Mockito {
   /**
    * The context.
    */
-  trait BaseContext extends Scope
+  trait Context extends BaseContext
 }

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProviderSpec.scala
@@ -18,7 +18,6 @@ package com.mohiva.play.silhouette.impl.providers.totp
 import com.mohiva.play.silhouette.api.util.Credentials
 import com.mohiva.play.silhouette.impl.providers.{ TotpInfo, TotpProviderSpec }
 import com.warrenstrange.googleauth.GoogleAuthenticator
-import com.mohiva.play.silhouette.impl.providers.TotpProvider
 import play.api.test.WithApplication
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -65,16 +64,8 @@ class GoogleTotpProviderSpec extends TotpProviderSpec {
 
     "return None when the plain scratch code is null or empty" in new WithApplication with Context {
       val result = provider.createCredentials(credentials.identifier)
-      await(provider.authenticate(result.totpInfo.withoutPlain, null.asInstanceOf[String])) should be(None)
-      await(provider.authenticate(result.totpInfo.withoutPlain, "")) should be(None)
-    }
-
-    "throw an IllegalArgumentException when the TotpInfo plain scratch codes aren't cleared out" in new WithApplication with Context {
-      val result = provider.createCredentials(credentials.identifier)
-      await(provider.authenticate(result.totpInfo, testWrongVerificationCode)) must throwA[IllegalArgumentException].like {
-        case e =>
-          e.getMessage must beEqualTo(TotpProvider.ScratchCodesMustBeClearedOut)
-      }
+      await(provider.authenticate(result.totpInfo, null.asInstanceOf[String])) should be(None)
+      await(provider.authenticate(result.totpInfo, "")) should be(None)
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProviderSpec.scala
@@ -18,6 +18,7 @@ package com.mohiva.play.silhouette.impl.providers.totp
 import com.mohiva.play.silhouette.api.util.Credentials
 import com.mohiva.play.silhouette.impl.providers.{ TotpInfo, TotpProviderSpec }
 import com.warrenstrange.googleauth.GoogleAuthenticator
+import com.mohiva.play.silhouette.impl.providers.TotpProvider
 import play.api.test.WithApplication
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -64,8 +65,16 @@ class GoogleTotpProviderSpec extends TotpProviderSpec {
 
     "return None when the plain scratch code is null or empty" in new WithApplication with Context {
       val result = provider.createCredentials(credentials.identifier)
-      await(provider.authenticate(result.totpInfo, null.asInstanceOf[String])) should be(None)
-      await(provider.authenticate(result.totpInfo, "")) should be(None)
+      await(provider.authenticate(result.totpInfo.withoutPlain, null.asInstanceOf[String])) should be(None)
+      await(provider.authenticate(result.totpInfo.withoutPlain, "")) should be(None)
+    }
+
+    "throw an IllegalArgumentException when the TotpInfo plain scratch codes aren't cleared out" in new WithApplication with Context {
+      val result = provider.createCredentials(credentials.identifier)
+      await(provider.authenticate(result.totpInfo, testWrongVerificationCode)) must throwA[IllegalArgumentException].like {
+        case e =>
+          e.getMessage must beEqualTo(TotpProvider.ScratchCodesMustBeClearedOut)
+      }
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProviderSpec.scala
@@ -45,9 +45,9 @@ class GoogleTotpProviderSpec extends TotpProviderSpec {
   "The `createCredentials` method" should {
     "return the correct TotpCredentials shared key" in new WithApplication with Context {
       val result = provider.createCredentials(credentials.identifier)
-      result.sharedKey must not be empty
+      result.totpInfo.sharedKey must not be empty
+      result.totpInfo.scratchCodes must not be empty
       result.qrUrl must not be empty
-      result.scratchCodes must not be empty
     }
   }
 

--- a/silhouette/test/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProviderSpec.scala
+++ b/silhouette/test/com/mohiva/play/silhouette/impl/providers/totp/GoogleTotpProviderSpec.scala
@@ -16,8 +16,9 @@
 package com.mohiva.play.silhouette.impl.providers.totp
 
 import com.mohiva.play.silhouette.api.util.Credentials
-import com.mohiva.play.silhouette.impl.providers.TotpProviderSpec
-import play.api.test.{ FakeRequest, WithApplication }
+import com.mohiva.play.silhouette.impl.providers.{ TotpInfo, TotpProviderSpec }
+import com.warrenstrange.googleauth.GoogleAuthenticator
+import play.api.test.WithApplication
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -25,20 +26,25 @@ import scala.concurrent.ExecutionContext.Implicits.global
  * Test case for the [[com.mohiva.play.silhouette.impl.providers.totp.GoogleTotpProvider#GoogleTOTPProvider]] class.
  */
 class GoogleTotpProviderSpec extends TotpProviderSpec {
-  "The `authenticate` method" should {
+  "The `authenticate` with verification code method" should {
+    "return None when the sharedKey is null or empty" in new WithApplication with Context {
+      await(provider.authenticate(null.asInstanceOf[String], testVerificationCode)) should be(None)
+      await(provider.authenticate("", testVerificationCode)) should be(None)
+    }
+
     "return None when the verification code is null or empty" in new WithApplication with Context {
-      implicit val req = FakeRequest()
       await(provider.authenticate(testSharedKey, null)) should be(None)
       await(provider.authenticate(testSharedKey, "")) should be(None)
     }
 
-    "return None when the sharedKey is null" in new WithApplication with Context {
-      implicit val req = FakeRequest()
-      await(provider.authenticate(null, testVerificationCode)) should be(None)
-    }
-
     "return None when the verification code isn't a number" in new WithApplication with Context {
       await(provider.authenticate(testSharedKey, testWrongVerificationCode)) should be(None)
+    }
+
+    "return valid `Some(TotpInfo)` when the verification code is correct" in new WithApplication with Context {
+      val googleAuthenticator = new GoogleAuthenticator()
+      val validVerificationCode = googleAuthenticator.getTotpPassword(testSharedKey)
+      await(provider.authenticate(testSharedKey, validVerificationCode.toString)) should not be empty
     }
   }
 
@@ -48,6 +54,18 @@ class GoogleTotpProviderSpec extends TotpProviderSpec {
       result.totpInfo.sharedKey must not be empty
       result.totpInfo.scratchCodes must not be empty
       result.qrUrl must not be empty
+    }
+  }
+
+  "The `authenticate` with verification code method" should {
+    "return None when the input totpInfo is null" in new WithApplication with Context {
+      await(provider.authenticate(null.asInstanceOf[TotpInfo], testWrongVerificationCode)) should be(None)
+    }
+
+    "return None when the plain scratch code is null or empty" in new WithApplication with Context {
+      val result = provider.createCredentials(credentials.identifier)
+      await(provider.authenticate(result.totpInfo, null.asInstanceOf[String])) should be(None)
+      await(provider.authenticate(result.totpInfo, "")) should be(None)
     }
   }
 
@@ -78,6 +96,6 @@ class GoogleTotpProviderSpec extends TotpProviderSpec {
     /**
      * The provider to test.
      */
-    lazy val provider = new GoogleTotpProvider()
+    lazy val provider = new GoogleTotpProvider(passwordHasherRegistry)
   }
 }


### PR DESCRIPTION
Added correct handling of scratch or recovery codes, separated TotpInfo that can be safely stored from TotpCredentials that is intended for first and one time use.